### PR TITLE
Correct Tier 4 base cost

### DIFF
--- a/public/planetary/services/PlanetData.js
+++ b/public/planetary/services/PlanetData.js
@@ -19,7 +19,7 @@ app.constant("FACILITIES", {
 });
 
 app.constant("PRODUCT",{
-	TIER_COST:[4,400,7200,60000,1300000],
+	TIER_COST:[4,400,7200,60000,1200000],
 	TIER_VOLUME:[0.01, 0.38, 1.5, 6, 100]
 })
 


### PR DESCRIPTION
Base cost for Tier 4 product is 1,200,000 not 1,300,000

References:
- http://wiki.eveuniversity.org/Planetary_Interaction#Base_Costs
- https://web.archive.org/web/20160221205046/https://wiki.eveonline.com/en/wiki/Planetary_interaction#Taxes